### PR TITLE
Param for units and precise tz

### DIFF
--- a/eink_weather.ino
+++ b/eink_weather.ino
@@ -266,7 +266,7 @@ String callAPI(char *exclude, uint32_t when) {
   const char *api_format = \
     "https://api.pirateweather.net/forecast/" \
     "%s/%s,%s%s"                              \
-    "?units=si"                               \
+    "?units=%s"                               \
     "&exclude=%s";
 
   char api[220];
@@ -274,7 +274,7 @@ String callAPI(char *exclude, uint32_t when) {
   if (when != 0) {
     sprintf(whens, ",%d", when);
   }
-  sprintf(api, api_format, api_key, lat, lon, whens, exclude);
+  sprintf(api, api_format, api_key, lat, lon, whens, units, exclude);
 
   int retries = 0;
 

--- a/eink_weather.ino
+++ b/eink_weather.ino
@@ -267,9 +267,10 @@ String callAPI(char *exclude, uint32_t when) {
     "https://api.pirateweather.net/forecast/" \
     "%s/%s,%s%s"                              \
     "?units=%s"                               \
+    "&tz=precise"                             \
     "&exclude=%s";
 
-  char api[220];
+  char api[232];
   char whens[32] = "";
   if (when != 0) {
     sprintf(whens, ",%d", when);

--- a/params.h
+++ b/params.h
@@ -17,3 +17,6 @@ const char *lon     = "TODO";
 
 // The title to show at the top of the display
 const char *title   = "TODO";
+
+// units for display, possible values: ca,uk,us,si
+const char *units   = "si";


### PR DESCRIPTION
Add param 'units' so that people can set their preferred format.

Use tz=precise when fetching from api. Without this the pirateweather api was returning the wrong offset for San Francisco.